### PR TITLE
Update athena run instructions

### DIFF
--- a/IO/athena
+++ b/IO/athena
@@ -19,6 +19,7 @@ mkdir run
 cd run/
 
 ### run
+python -m AthenaPoolExampleAlgorithms.AthenaPoolExample_Write.py >& log0
 python -m AthenaPoolExampleAlgorithms.AthenaPoolExample_ReadWrite.py >& log1
 python -m AthenaPoolExampleAlgorithms.AthenaPoolExample_ReadWriteNext.py > log2
 python -m AthenaPoolExampleAlgorithms.AthenaPoolExample_WritexAODElectrons.py >& log3
@@ -31,3 +32,9 @@ cd build
 asetup Athena,main,latest
 source x86_64-el9-gcc13-opt/setup.sh
 cd ../run
+
+### View inside SimplePoolFile_xAOD.root
+checkxAOD SimplePoolFile_xAOD.root
+
+### To view all of the branches stored file
+checkFile SimplePoolFile_xAOD.root


### PR DESCRIPTION
The other unit tests don't run without `AthenaPoolExampleAlgorithms.AthenaPoolExample_Write.py` test running first.

Running the `ReadWrite.py` test first comes back not being able to read `SimplePoolFile1.root` since it hasn't been created by `Write.py` yet. 

`    raise OSError('Failed to open file {}'.format(str(args[0])))
OSError: Failed to open file SimplePoolFile1.root`